### PR TITLE
feat: add X-XR-Plugin flag to .desktop file

### DIFF
--- a/org.stardustxr.Telescope.desktop
+++ b/org.stardustxr.Telescope.desktop
@@ -5,3 +5,4 @@ Exec=telescope
 Type=Application
 Icon=org.stardustxr.Telescope
 Categories=Utility;X-WiVRn-VR;
+X-XR-Plugin=true


### PR DESCRIPTION
This change is part of a new initiative in Envision to revamp the plugin system. The new system is such that Envision will no longer install plugins on its own, instead it will detect system provided plugin applications via the X-XR-Plugin flag, and be instructed on a specific command to use with the optional X-XR-Plugin-Exec.

This proposed specification is detailed in the following issue: <https://gitlab.com/gabmus/envision/-/issues/250>